### PR TITLE
Add a custom StartDate option to trackRecord feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 dist
 node_modules
-.idea/*

--- a/README.md
+++ b/README.md
@@ -115,42 +115,46 @@ Returns:
 
 ### `trackRecord`
 
-Track record returns a list of dates from today into the past with the provided dates marked as `true`. This is especially helpful for features where you want to show users a calendar of dates where they completed some task.
+Track record returns a list of dates from a date into the past with the provided dates marked as `true`. This is especially helpful for features where you want to show users a calendar of dates where they completed some task. By defaulted 
 
 #### Example
 
-Let's assume today is 1/10/2018.
+Let's assume today is 1/10/2018. But want to get a track record for the current week with end date 1/13/2018.
 
 ```js
 import { trackRecord } from 'date-streaks';
 
 const dates = [
-  new Date('01/01/2018'),
-  new Date('01/02/2018'),
-  new Date('01/08/2018'),
-  new Date('01/09/2018')
+  new Date('01/04/2018'),
+  new Date('01/05/2018'),
+  new Date('01/11/2018'),
+  new Date('01/12/2018')
 ];
 
 // defaults to 7 days
 const length = 10;
 
-trackRecord({ dates, length }); // object filled w/ {dates:Array, length:Number}
+// defaults to today's date
+const startDate = new Date('01/13/2018');
+
+
+trackRecord({ dates, length, startDate }); // object filled w/ {dates:Array, length:Number, startDate: Date}
 ```
 
 Returns:
 
 ```js
 {
-  'Wed Jan 10 2018 00:00:00 GMT-0400': false,
-  'Tue Jan 09 2018 00:00:00 GMT-0400': true,
-  'Mon Jan 08 2018 00:00:00 GMT-0400': true,
-  'Sun Jan 07 2018 00:00:00 GMT-0400': false,
-  'Sat Jan 06 2018 00:00:00 GMT-0400': false,
-  'Fri Jan 05 2018 00:00:00 GMT-0400': false,
-  'Thu Jan 04 2018 00:00:00 GMT-0400': false,
-  'Wed Jan 03 2018 00:00:00 GMT-0400': false,
-  'Tue Jan 02 2018 00:00:00 GMT-0400': true,
-  'Mon Jan 01 2018 00:00:00 GMT-0400': true
+  'Wed Jan 13 2018 00:00:00 GMT-0400': false,
+  'Tue Jan 12 2018 00:00:00 GMT-0400': true,
+  'Mon Jan 11 2018 00:00:00 GMT-0400': true,
+  'Sun Jan 10 2018 00:00:00 GMT-0400': false,
+  'Sat Jan 09 2018 00:00:00 GMT-0400': false,
+  'Fri Jan 08 2018 00:00:00 GMT-0400': false,
+  'Thu Jan 07 2018 00:00:00 GMT-0400': false,
+  'Wed Jan 06 2018 00:00:00 GMT-0400': false,
+  'Tue Jan 05 2018 00:00:00 GMT-0400': true,
+  'Mon Jan 04 2018 00:00:00 GMT-0400': true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Track record returns a list of dates from a specified date into the past with th
 
 #### Example
 
-Let's assume today is 1/10/2018. But want to get a track record for the current week with end date 1/13/2018.
+Let's get a track record for the days preceeding 1/13/2018.
 
 ```js
 import { trackRecord } from 'date-streaks';

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const dates = [
 const length = 10;
 
 // defaults to today's date
-const startDate = new Date('01/13/2018');
+const endDate = new Date('01/13/2018');
 
 
 trackRecord({ dates, length, endDate });

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ const length = 10;
 const startDate = new Date('01/13/2018');
 
 
-trackRecord({ dates, length, startDate }); // object filled w/ {dates:Array, length:Number, startDate: Date}
+trackRecord({ dates, length, endDate });
 ```
 
 Returns:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Returns:
 
 ### `trackRecord`
 
-Track record returns a list of dates from a date into the past with the provided dates marked as `true`. This is especially helpful for features where you want to show users a calendar of dates where they completed some task. By defaulted 
+Track record returns a list of dates from a specified date into the past with the provided dates marked as `true`. This is especially helpful for features where you want to show users a calendar of dates where they completed some task.
 
 #### Example
 

--- a/src/trackRecord.js
+++ b/src/trackRecord.js
@@ -1,10 +1,10 @@
 import startOfDay from 'date-fns/start_of_day';
 import subDays from 'date-fns/sub_days';
-import { sortDates } from './helpers';
+import {sortDates} from './helpers';
 
-const trackRecord = ({ dates = [], length = 7 }) => {
+const trackRecord = ({ dates = [], length = 7, startDate = new Date() }) => {
   const pastDates = [...Array(length)].map((_, i) =>
-    startOfDay(subDays(new Date(), i))
+    startOfDay(subDays(startDate, i))
   );
   const sortedDates = sortDates(dates).map(date => startOfDay(date).getTime());
 

--- a/src/trackRecord.js
+++ b/src/trackRecord.js
@@ -2,7 +2,7 @@ import startOfDay from 'date-fns/start_of_day';
 import subDays from 'date-fns/sub_days';
 import {sortDates} from './helpers';
 
-const trackRecord = ({ dates = [], length = 7, startDate = new Date() }) => {
+const trackRecord = ({ dates = [], length = 7, endDate = new Date() }) => {
   const pastDates = [...Array(length)].map((_, i) =>
     startOfDay(subDays(startDate, i))
   );

--- a/src/trackRecord.js
+++ b/src/trackRecord.js
@@ -4,7 +4,7 @@ import {sortDates} from './helpers';
 
 const trackRecord = ({ dates = [], length = 7, endDate = new Date() }) => {
   const pastDates = [...Array(length)].map((_, i) =>
-    startOfDay(subDays(startDate, i))
+    startOfDay(subDays(endDate, i))
   );
   const sortedDates = sortDates(dates).map(date => startOfDay(date).getTime());
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const { getDatesParameter } = require('../dist/helpers')
+const { getDatesParameter, sortDates } = require('../dist/helpers');
 
 describe('Helpers', () => {
   describe('getDatesParameter', () => {
@@ -14,6 +14,24 @@ describe('Helpers', () => {
     });
     it('should return array when array is passed', () => {
       expect(getDatesParameter([1,2])).to.deep.equal([1,2]);
+    });
+  });
+
+  describe('sortDates', () => {
+    it('should accept an empty array as input', () => {
+      let result = sortDates([]);
+      let isSorted = result.every((date, index) => !index || result[index-1] <= date);
+      expect(isSorted).to.equal(true);
+    });
+
+    it('should return a sorted array', () => {
+      let result = sortDates([
+        new Date('01/04/2018'),
+        new Date('01/01/2018'),
+        new Date('01/03/2018'),
+      ]);
+      let isSorted = result.every((date, index) => !index || result[index-1] <= date);
+      expect(isSorted).to.equal(true);
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -170,7 +170,7 @@ describe('Date Streaks', () => {
       expect(Object.keys(result).length).to.equal(10);
     });
 
-    it('should take a custom start date', () => {
+    it('should take a custom end date', () => {
       var today = startOfDay(new Date());
       var result = trackRecord({dates: [today], startDate: endOfWeek(new Date())});
       expect(result[today]).to.equal(true);

--- a/test/index.js
+++ b/test/index.js
@@ -176,7 +176,7 @@ describe('Date Streaks', () => {
       expect(result[today]).to.equal(true);
     });
 
-    it('should take a custom length of days and a custom start date', () => {
+    it('should take a custom length of days and a custom end date', () => {
       var today = startOfDay(new Date());
       var result = trackRecord({dates: [today], length: 10, startDate: endOfWeek(new Date())});
       expect(result[today]).to.equal(true);

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-var { startOfDay, subDays, addDays } = require('date-fns');
+var { startOfDay, endOfWeek, subDays, addDays } = require('date-fns');
 var expect = require('chai').expect;
 var summary = require('../dist/summary').default;
 var trackRecord = require('../dist/trackRecord').default;
@@ -168,6 +168,25 @@ describe('Date Streaks', () => {
     it('should take a custom length of days', () => {
       var result = trackRecord({ dates: [new Date('3/19/2018')], length: 10 });
       expect(Object.keys(result).length).to.equal(10);
+    });
+
+    it('should take a custom start date', () => {
+      var today = startOfDay(new Date());
+      var result = trackRecord({dates: [today], startDate: endOfWeek(new Date())});
+      expect(result[today]).to.equal(true);
+    });
+
+    it('should take a custom length of days and a custom start date', () => {
+      var today = startOfDay(new Date());
+      var result = trackRecord({dates: [today], length: 10, startDate: endOfWeek(new Date())});
+      expect(result[today]).to.equal(true);
+    });
+
+
+    it('should accept an empty array as input', () => {
+      var result = trackRecord({ dates: [] });
+      debugger;
+      expect(Object.keys(result).length).to.equal(7);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -178,7 +178,7 @@ describe('Date Streaks', () => {
 
     it('should take a custom length of days and a custom end date', () => {
       var today = startOfDay(new Date());
-      var result = trackRecord({dates: [today], length: 10, startDate: endOfWeek(new Date())});
+      var result = trackRecord({dates: [today], length: 10, endDate: endOfWeek(new Date())});
       expect(result[today]).to.equal(true);
     });
 


### PR DESCRIPTION
Expanded the `trackRecord()` feature to allow Users to select a StartDate in which they want the trackRecord to start at. Right now it defaults to today's date, but I was hoping that it could calculate trackRecords for a specific week, starting at the end of that week. So thought, adding the custom `StartDate` will solve for this usecase and other similar use cases in which a User doesn't want to use today's date for the start of the TrackRecord.

## Changelog: 

- Accept a custom `StartDate` (optional) in `trackRecord()`
- Created tests for custom `StartDate`
- Created tests for `sortDates` in `helper.js` to check for empty arrays.
- Updated README.md TrackRecord section with new custom 'StartDate' option.

![IMG_7391](https://user-images.githubusercontent.com/8572223/75845409-d85d8180-5d8d-11ea-8497-233c974446e7.PNG)
